### PR TITLE
fix: add sig verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2088,12 +2088,19 @@
         "react-pdf": "^5.2.0",
         "stream-browserify": "^3.0.0",
         "typesafe-actions": "^5.1.0"
+      },
+      "dependencies": {
+        "penpal-v4": {
+          "version": "npm:penpal@4.1.1",
+          "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
+          "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
+        }
       }
     },
     "@govtechsg/dnsprove": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.5.0.tgz",
-      "integrity": "sha512-aUrLPF1DeydxKRJsLW++vQoTGXkUoP8zbHwaUU63vFar7pBZ/1UIWr/QJlYGmyVgZ++eQlHeKaiC+Zp3ix2Qag==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.6.1.tgz",
+      "integrity": "sha512-ALLe3EC9ix6ZsMIHgRRLdVYMC35yRShG8sRXb73D4bvw60Yz/pT/Y3e9w40KqG8HMMChvJaEMV6uQi6GR7Jwmw==",
       "requires": {
         "axios": "^0.21.1",
         "debug": "^4.3.1",
@@ -2117,14 +2124,14 @@
       }
     },
     "@govtechsg/oa-verify": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@govtechsg/oa-verify/-/oa-verify-8.0.0.tgz",
-      "integrity": "sha512-COXOypaQMXN3BCEV13Q9oD9SzaPIOf2M4cwiryIUS0CfNkkK3iCQyjM5REGdpk3jO8YRn4WjYLpNiAdr8xHxvA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@govtechsg/oa-verify/-/oa-verify-8.2.1.tgz",
+      "integrity": "sha512-Hfp+JwCulj7lcpydPZgF7DEqZmRHlES/zH+ZXWC/zUpRBWXCLnyup3cXTmEX5b1pM8QHpL7ky0+wDmbN71K8WA==",
       "requires": {
-        "@govtechsg/dnsprove": "^2.5.0",
+        "@govtechsg/dnsprove": "^2.6.1",
         "@govtechsg/document-store": "^2.2.3",
         "@govtechsg/open-attestation": "^6.2.0",
-        "@govtechsg/token-registry": "^2.5.3",
+        "@govtechsg/token-registry": "^4.1.7",
         "axios": "^0.21.4",
         "debug": "^4.3.1",
         "did-resolver": "^3.1.0",
@@ -2156,9 +2163,12 @@
       }
     },
     "@govtechsg/token-registry": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@govtechsg/token-registry/-/token-registry-2.6.1.tgz",
-      "integrity": "sha512-QnAIlYeGD4zHtYPiZ46SIe6hFc3HyMKvyBJIdlsFxHscMR4f8AENIyUS2AKhqJibCcN2beNJy/bPWlCAtHoT7w=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@govtechsg/token-registry/-/token-registry-4.2.0.tgz",
+      "integrity": "sha512-9CbyYxoq5g/athuKHyB5SMk2qsZOt6OoNX9B4D4PLnBuzkXkCio19cyqh9hg2XBjlvkQwOPYS6fnvXqtDsBu+w==",
+      "requires": {
+        "@typechain/ethers-v5": "~10.0.0"
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -4204,6 +4214,15 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
+    },
+    "@typechain/ethers-v5": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-10.0.0.tgz",
+      "integrity": "sha512-Kot7fwAqnH96ZbI8xrRgj5Kpv9yCEdjo7mxRqrH7bYpEgijT5MmuOo8IVsdhOu7Uog4ONg7k/d5UdbAtTKUgsA==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      }
     },
     "@types/aria-query": {
       "version": "5.0.1",
@@ -14336,11 +14355,6 @@
       "resolved": "https://registry.npmjs.org/penpal/-/penpal-5.3.0.tgz",
       "integrity": "sha512-ezGckenx66j3RShl4nZiswjgDxyoDaJJ9tLBp46UvVxlA9MlIPF6hWfuppw1AzaDKgUULU1i44QFOuI4SXY/mg=="
     },
-    "penpal-v4": {
-      "version": "npm:penpal@4.1.1",
-      "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
-      "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -17730,6 +17744,11 @@
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
+    "ts-essentials": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
+      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ=="
+    },
     "ts-typed-json": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ts-typed-json/-/ts-typed-json-0.3.2.tgz",
@@ -18144,18 +18163,34 @@
       }
     },
     "web-did-resolver": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/web-did-resolver/-/web-did-resolver-2.0.21.tgz",
-      "integrity": "sha512-vKYz0s9spYfYrKhrF88F44lkofS1yj6TCF40+i077a7boru2BNROl5VZEIVL9jJRUDsNzvmVSKkq3kS8kZnB2Q==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/web-did-resolver/-/web-did-resolver-2.0.27.tgz",
+      "integrity": "sha512-YxQlNdeYBXLhVpMW62+TPlc6sSOiWyBYq7DNvY6FXmXOD9g0zLeShpq2uCKFFQV/WlSrBi/yebK/W5lMTDxMUQ==",
       "requires": {
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^4.0.0",
         "did-resolver": "^4.0.0"
       },
       "dependencies": {
+        "cross-fetch": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+          "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+          "requires": {
+            "node-fetch": "^2.6.12"
+          }
+        },
         "did-resolver": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-4.1.0.tgz",
           "integrity": "sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA=="
+        },
+        "node-fetch": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+          "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@govtechsg/decentralized-renderer-react-components": "^3.8.0",
-    "@govtechsg/oa-verify": "../open-xxx/oa-verify",
+    "@govtechsg/oa-verify": "^8.2.1",
     "@govtechsg/open-attestation": "^6.6.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@govtechsg/decentralized-renderer-react-components": "^3.8.0",
-    "@govtechsg/oa-verify": "^8.0.0",
+    "@govtechsg/oa-verify": "../open-xxx/oa-verify",
     "@govtechsg/open-attestation": "^6.6.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",


### PR DESCRIPTION
This pr adds in the verification of the signature of the Combined VC into the custom NDI verifier.

This requires a DID-resolver which could be created from the `createResolver` function exposed by oa-verify.
Also requires the `verifySignature` helper function that is currently private to oa-verify.

Do we need to use these convenience functions? Not entirely so.